### PR TITLE
fix(terraform): replace deprecated inline_policy with aws_iam_role_policy

### DIFF
--- a/.github/workflows/terraform-test.yml
+++ b/.github/workflows/terraform-test.yml
@@ -1,0 +1,86 @@
+---
+name: Terraform Terratest with Go
+on:        # yamllint disable-line rule:truthy
+  pull_request:
+    types: [opened]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull Request Number'
+        required: true
+
+permissions:
+  id-token: write
+  contents: read
+  statuses: write  # Required for setting commit status
+
+jobs:
+  terratest:
+    runs-on: ubuntu-latest
+    name: Terratest Checks
+
+    env:
+      PR_NUMBER: >-
+        ${{ github.event_name == 'workflow_dispatch' &&
+        github.event.inputs.pr_number || github.event.pull_request.number }}
+
+
+    steps:
+      - name: Checkout PR code
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ env.PR_NUMBER }}/head
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.ARC_IAC_TERRATEST_ROLE }}
+          aws-region: us-east-1
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.24'
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.5.7
+          terraform_wrapper: false
+
+      - name: Create test directory and download go from S3
+        run: |
+          mkdir -p terra-test
+          aws s3 cp ${{ secrets.ARC_TERRATEST_GO_FILE }} terra-test/terra_test.go
+      - name: Initialize Go module and install dependencies
+        run: |
+          cd terra-test
+          ls
+          go mod init terraform-test || true
+          go get github.com/gruntwork-io/terratest/modules/terraform
+          go get github.com/stretchr/testify/assert
+          go mod tidy
+          go test -v -timeout 40m
+      - name: Report check status manually
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr_number = parseInt(process.env.PR_NUMBER);
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr_number,
+            });
+            const sha = pr.data.head.sha;
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: sha,
+              state: 'success',
+              context: 'terratest',
+              description: 'Manual terratest completed successfully',
+              target_url:
+                `https://github.com/${context.repo.owner}/${context.repo.repo}` +
+                `/actions/runs/${process.env.GITHUB_RUN_ID}`,
+            });

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .terraform
 *.tfstate*
-terraform.tfvars
 *.backup
 .idea
 .external_momdules

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ terraform destroy -var-file dev.tfvars
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.57.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.97.0 |
 
 ## Modules
 
@@ -298,6 +298,7 @@ terraform destroy -var-file dev.tfvars
 | [aws_eip.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
 | [aws_iam_instance_profile.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.managed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_instance.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_volume_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/volume_attachment) | resource |

--- a/example/data.tf
+++ b/example/data.tf
@@ -1,3 +1,5 @@
+data "aws_caller_identity" "current" {}
+
 data "aws_vpc" "this" {
   filter {
     name   = "tag:Name"

--- a/example/locals.tf
+++ b/example/locals.tf
@@ -70,7 +70,7 @@ locals {
           port            = "443"
           protocol        = "HTTPS"
           ssl_policy      = "ELBSecurityPolicy-TLS13-1-2-2021-06"
-          certificate_arn = "arn:aws:acm:us-east-1:xxxx:certificate/xx-xx-xx-xx-xx"
+          certificate_arn = "arn:aws:acm:us-east-1:${data.aws_caller_identity.current.account_id}:certificate/d341450e-c196-4617-a122-478c0e070a25"
 
           default_action = {
             type = "forward"

--- a/example/terraform.tfvars
+++ b/example/terraform.tfvars
@@ -1,0 +1,2 @@
+namespace   = "arc"
+environment = "poc"

--- a/main.tf
+++ b/main.tf
@@ -147,7 +147,6 @@ resource "aws_iam_role" "this" {
   })
 }
 
-
 resource "aws_iam_role_policy_attachment" "managed" {
   for_each = var.instance_profile_data.create ? toset(var.instance_profile_data.managed_policy_arns) : []
 

--- a/main.tf
+++ b/main.tf
@@ -146,17 +146,18 @@ resource "aws_iam_role" "this" {
     ]
   })
 
-  dynamic "inline_policy" {
-    for_each = var.instance_profile_data.policy_documents
-    content {
-      name   = inline_policy.value.name
-      policy = inline_policy.value.policy
-    }
-  }
-
   managed_policy_arns = var.instance_profile_data.managed_policy_arns
-
 }
+
+resource "aws_iam_role_policy" "inline" {
+  for_each = var.instance_profile_data.create ? { for p in var.instance_profile_data.policy_documents : p.name => p } : {}
+
+  name   = each.value.name
+  role   = aws_iam_role.this[0].name
+  policy = each.value.policy
+}
+
+
 
 resource "aws_eip" "this" {
   count = var.associate_public_ip_address && var.assign_eip ? 1 : 0

--- a/main.tf
+++ b/main.tf
@@ -145,17 +145,16 @@ resource "aws_iam_role" "this" {
       }
     ]
   })
-
-  managed_policy_arns = var.instance_profile_data.managed_policy_arns
 }
 
-resource "aws_iam_role_policy" "inline" {
-  for_each = var.instance_profile_data.create ? { for p in var.instance_profile_data.policy_documents : p.name => p } : {}
 
-  name   = each.value.name
-  role   = aws_iam_role.this[0].name
-  policy = each.value.policy
+resource "aws_iam_role_policy_attachment" "managed" {
+  for_each = var.instance_profile_data.create ? toset(var.instance_profile_data.managed_policy_arns) : []
+
+  role       = aws_iam_role.this[0].name
+  policy_arn = each.value
 }
+
 
 
 


### PR DESCRIPTION
## Description

Terraform configuration by replacing the deprecated `inline_policy` argument in the `aws_iam_role` resource with the recommended `aws_iam_role_policy `resource.

## Related Issue

- [Issue Number](link-to-issue): Brief description

## Checklist

Please ensure that the following steps are completed before submitting the pull request:

- [X] Code follows the Terraform best practices and style guidelines.
- [ ] Changes are appropriately documented, including any necessary updates to README or other documentation files.
- [ ] Unit tests have been added or updated to cover the changes introduced by this pull request.
- [X] Changes have been tested locally and verified to work as expected.
- [ ] The code has been reviewed to ensure it aligns with the project's goals and standards.
- [ ] Dependencies and backward compatibility have been considered and addressed if applicable.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## Testing Instructions

Provide detailed steps or instructions for testing the changes introduced by this pull request.

## Screenshots

![image](https://github.com/user-attachments/assets/b5fbd932-bc6a-43a2-8ec7-7d503d7e18d8)


## Additional Notes

Add any additional notes or context that might be helpful for reviewers or users testing the changes.
